### PR TITLE
Launch IPython directly from package, instead of from path

### DIFF
--- a/spin/cmds/meson.py
+++ b/spin/cmds/meson.py
@@ -766,7 +766,10 @@ def ipython(ctx, *, ipython_args, build=None, build_dir=None, pre_import=""):
         print(f'💻 Launching IPython with PYTHONPATH="{p}"')
     if pre_import:
         ipython_args = (f"--TerminalIPythonApp.exec_lines={pre_import}",) + ipython_args
-    _run(["ipython", "--ignore-cwd"] + list(ipython_args), replace=True)
+    _run(
+        [sys.executable, "-P", "-m", "IPython", "--ignore-cwd"] + list(ipython_args),
+        replace=True,
+    )
 
 
 @click.command()


### PR DESCRIPTION
It happens, sometimes, that an install from a different version of Python is on the path. That leads to some unexepected and hard to debug issues.

This uses the `-P` flag which requires Python 3.11 (EOL for 3.10 is June 2026).