### PR TITLE
Click 8.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
   "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
+  "click>=8,<=8.2; python_version == '3.10'",  # cannot deepcopy cmd params (specifically, Sentinel.UNSET) on 3.10
   "click>=8,!=8.3.0,<8.4",
   "tomli; python_version < '3.11'",
   "colorama; platform_system == 'Windows'",


### PR DESCRIPTION
Re-opening #297

> Click 8.3.0 broke spin because Sentinel objects are now passed instead of defaults in some instances:
>
> https://github.com/pallets/click/issues/3065
>
> 8.3.1 will include two workarounds:
>
> https://github.com/pallets/click/issues/3065#issuecomment-3334011895
>
> I suspect
>
> https://github.com/pallets/click/pull/3068
>
> will address our problem.